### PR TITLE
Update module name in go.mod to reflect the new directory structure

### DIFF
--- a/serial-lib/go/mobitec/go.mod
+++ b/serial-lib/go/mobitec/go.mod
@@ -1,4 +1,4 @@
-module github.com/prefixFelix/mobitec-flipdot/src/go/mobitec
+module github.com/prefixFelix/mobitec-flipdot/serial-lib/go/mobitec
 
 go 1.20
 


### PR DESCRIPTION
Otherwise, the following error occurs:

```
% go install github.com/prefixFelix/mobitec-flipdot/serial-lib/go/mobitec@latest
go: downloading github.com/prefixFelix/mobitec-flipdot/serial-lib/go/mobitec v0.0.0-20250303222119-bbd2e3c416bd
go: github.com/prefixFelix/mobitec-flipdot/serial-lib/go/mobitec@latest: github.com/prefixFelix/mobitec-flipdot/serial-lib/go/mobitec@v0.0.0-20250303222119-bbd2e3c416bd: parsing go.mod:
	module declares its path as: github.com/prefixFelix/mobitec-flipdot/src/go/mobitec
	        but was required as: github.com/prefixFelix/mobitec-flipdot/serial-lib/go/mobitec
```